### PR TITLE
feat(tokens): add support for our RosettaColor class

### DIFF
--- a/dist/cjs/core.js
+++ b/dist/cjs/core.js
@@ -92,7 +92,13 @@ var createParser = function createParser(config) {
         }
 
         if (raw !== null) {
-          styles = merge(styles, parseResponsiveObject(cache.breakpoints, sx, scale, raw, props));
+          // We have a style class
+          if (raw.valueOf() !== raw) {
+            styles = merge(styles, sx(raw, scale, props));
+          } else {
+            styles = merge(styles, parseResponsiveObject(cache.breakpoints, sx, scale, raw, props));
+          }
+
           shouldSort = true;
         }
 

--- a/dist/esm/core.js
+++ b/dist/esm/core.js
@@ -80,7 +80,13 @@ export var createParser = function createParser(config) {
         }
 
         if (raw !== null) {
-          styles = merge(styles, parseResponsiveObject(cache.breakpoints, sx, scale, raw, props));
+          // We have a style class
+          if (raw.valueOf() !== raw) {
+            styles = merge(styles, sx(raw, scale, props));
+          } else {
+            styles = merge(styles, parseResponsiveObject(cache.breakpoints, sx, scale, raw, props));
+          }
+
           shouldSort = true;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tmp-styled-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tmp-styled-system",
   "main": "dist/cjs/styled-system.js",
   "module": "dist/esm/styled-system.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm",

--- a/src/backwards-compat-tests/core/parser.test.js
+++ b/src/backwards-compat-tests/core/parser.test.js
@@ -1,9 +1,23 @@
-import { system, compose } from '../../core';
+import { system } from '../../core';
+
+class RosettaColor extends String {
+  constructor(...args) {
+    super(args);
+
+    this['100'] = 'orange';
+    this['200'] = 'yellow';
+  }
+
+  valueOf() {
+    return 'red';
+  }
+}
 
 const theme = {
   colors: {
     primary: 'rebeccapurple',
-    secondary: 'papayawhip'
+    secondary: 'papayawhip',
+    tertiary: new RosettaColor()
   },
   fontSize: [0, 4, 8, 16]
 };
@@ -159,4 +173,40 @@ test('uses custom media query breakpoints', () => {
   };
   expect(styles).toEqual(expected);
   expect(styles2).toEqual(expected);
+});
+
+test('supports rosetta colors class', () => {
+  const styles1 = parser({
+    theme: theme,
+    color: 'tertiary'
+  });
+
+  const expected1 = {
+    color: new RosettaColor()
+  };
+
+  expect(styles1).toEqual(expected1);
+  expect(styles1.color.valueOf()).toEqual('red');
+
+  const styles2 = parser({
+    theme: theme,
+    color: 'tertiary.100'
+  });
+
+  const expected2 = {
+    color: 'orange'
+  };
+
+  expect(styles2).toEqual(expected2);
+
+  const styles3 = parser({
+    theme: theme,
+    color: 'tertiary.200'
+  });
+
+  const expected3 = {
+    color: 'yellow'
+  };
+
+  expect(styles3).toEqual(expected3);
 });

--- a/src/core.js
+++ b/src/core.js
@@ -79,10 +79,15 @@ export const createParser = config => {
           continue;
         }
         if (raw !== null) {
-          styles = merge(
-            styles,
-            parseResponsiveObject(cache.breakpoints, sx, scale, raw, props)
-          );
+          // We have a style class
+          if (raw.valueOf() !== raw) {
+            styles = merge(styles, sx(raw, scale, props));
+          } else {
+            styles = merge(
+              styles,
+              parseResponsiveObject(cache.breakpoints, sx, scale, raw, props)
+            );
+          }
           shouldSort = true;
         }
         continue;


### PR DESCRIPTION
Craig added this feature in a patch to support our backwards compatible RosettaColor class. This allows us to have a color value for red that can be accessed in multiple ways:

`colors.red` returns a string representation of the default red.
`colors.red['100']` (through '900') returns an individual red hex from our range of tokens.

This is enabled by adding a `valueOf` method to the RosettaColor class that returns the default string.