### PR TITLE
Bcryer/DP 2605 backwards compatible css

### DIFF
--- a/dist/cjs/backwards-compat-tests/core/parser.test.js
+++ b/dist/cjs/backwards-compat-tests/core/parser.test.js
@@ -2,12 +2,17 @@
 
 var _core = require("../../core");
 
+var _RosettaColor = _interopRequireDefault(require("../../testUtilities/RosettaColor"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 var theme = {
   colors: {
     primary: 'rebeccapurple',
-    secondary: 'papayawhip'
+    secondary: 'papayawhip',
+    tertiary: new _RosettaColor["default"]()
   },
   fontSize: [0, 4, 8, 16]
 };
@@ -149,4 +154,31 @@ test('uses custom media query breakpoints', function () {
   };
   expect(styles).toEqual(expected);
   expect(styles2).toEqual(expected);
+});
+test('supports rosetta colors class', function () {
+  var styles1 = parser({
+    theme: theme,
+    color: 'tertiary'
+  });
+  var expected1 = {
+    color: new _RosettaColor["default"]()
+  };
+  expect(styles1).toEqual(expected1);
+  expect(styles1.color.valueOf()).toEqual('red');
+  var styles2 = parser({
+    theme: theme,
+    color: 'tertiary.100'
+  });
+  var expected2 = {
+    color: 'orange'
+  };
+  expect(styles2).toEqual(expected2);
+  var styles3 = parser({
+    theme: theme,
+    color: 'tertiary.200'
+  });
+  var expected3 = {
+    color: 'yellow'
+  };
+  expect(styles3).toEqual(expected3);
 });

--- a/dist/cjs/css.js
+++ b/dist/cjs/css.js
@@ -288,7 +288,14 @@ var css = function css(args) {
       var scaleName = get(scales, prop);
       var scale = get(theme, scaleName, get(theme, prop, {}));
       var transform = get(transforms, prop, get);
-      var value = transform(scale, val, val);
+      /**
+       * In order to be backwards compatible with old tokens, 
+       * we need to call valueOf() on values which use the 
+       * RosettaColor class.
+       **/
+
+      var tempValue = transform(scale, val, val);
+      var value = tempValue !== undefined ? tempValue.valueOf() : tempValue;
 
       if (multiples[prop]) {
         var dirs = multiples[prop];

--- a/dist/cjs/new-tests/css.test.js
+++ b/dist/cjs/new-tests/css.test.js
@@ -2,7 +2,21 @@
 
 var _css = _interopRequireDefault(require("../css"));
 
+var _RosettaColor = _interopRequireDefault(require("../testUtilities/RosettaColor"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _templateObject() {
+  var data = _taggedTemplateLiteralLoose(["\n  token         | value\n  ", "    | ", "\n  ", "      | ", "\n  ", "  | ", "\n  ", " | ", "\n"]);
+
+  _templateObject = function _templateObject() {
+    return data;
+  };
+
+  return data;
+}
+
+function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
 var theme = {
   breakpoints: {
@@ -42,5 +56,24 @@ test('match breakpoints wildcard', function () {
     '@media tablet-100': {
       fontSize: 64
     }
+  });
+});
+test.each(_templateObject(), 'green', 'green', 'red', 'red', 'red.100', 'orange', 'blue.100', 'blue')('converts $token to $value', function (_ref) {
+  var token = _ref.token,
+      value = _ref.value;
+  var colorTheme = {
+    colors: {
+      green: 'green',
+      red: new _RosettaColor["default"](),
+      blue: {
+        '100': 'blue'
+      }
+    }
+  };
+  var resolved = (0, _css["default"])({
+    color: token
+  })(colorTheme);
+  expect(resolved).toEqual({
+    color: value
   });
 });

--- a/dist/cjs/testUtilities/RosettaColor.js
+++ b/dist/cjs/testUtilities/RosettaColor.js
@@ -1,0 +1,48 @@
+"use strict";
+
+exports.__esModule = true;
+exports["default"] = void 0;
+
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var RosettaColor =
+/*#__PURE__*/
+function (_String) {
+  _inheritsLoose(RosettaColor, _String);
+
+  function RosettaColor() {
+    var _this;
+
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _String.call(this, args) || this;
+    _this['100'] = 'orange';
+    _this['200'] = 'yellow';
+    return _this;
+  }
+
+  var _proto = RosettaColor.prototype;
+
+  _proto.valueOf = function valueOf() {
+    return 'red';
+  };
+
+  return RosettaColor;
+}(_wrapNativeSuper(String));
+
+var _default = RosettaColor;
+exports["default"] = _default;

--- a/dist/esm/backwards-compat-tests/core/parser.test.js
+++ b/dist/esm/backwards-compat-tests/core/parser.test.js
@@ -1,10 +1,12 @@
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-import { system, compose } from '../../core';
+import { system } from '../../core';
+import RosettaColor from '../../testUtilities/RosettaColor';
 var theme = {
   colors: {
     primary: 'rebeccapurple',
-    secondary: 'papayawhip'
+    secondary: 'papayawhip',
+    tertiary: new RosettaColor()
   },
   fontSize: [0, 4, 8, 16]
 };
@@ -146,4 +148,31 @@ test('uses custom media query breakpoints', function () {
   };
   expect(styles).toEqual(expected);
   expect(styles2).toEqual(expected);
+});
+test('supports rosetta colors class', function () {
+  var styles1 = parser({
+    theme: theme,
+    color: 'tertiary'
+  });
+  var expected1 = {
+    color: new RosettaColor()
+  };
+  expect(styles1).toEqual(expected1);
+  expect(styles1.color.valueOf()).toEqual('red');
+  var styles2 = parser({
+    theme: theme,
+    color: 'tertiary.100'
+  });
+  var expected2 = {
+    color: 'orange'
+  };
+  expect(styles2).toEqual(expected2);
+  var styles3 = parser({
+    theme: theme,
+    color: 'tertiary.200'
+  });
+  var expected3 = {
+    color: 'yellow'
+  };
+  expect(styles3).toEqual(expected3);
 });

--- a/dist/esm/css.js
+++ b/dist/esm/css.js
@@ -278,7 +278,14 @@ export var css = function css(args) {
       var scaleName = get(scales, prop);
       var scale = get(theme, scaleName, get(theme, prop, {}));
       var transform = get(transforms, prop, get);
-      var value = transform(scale, val, val);
+      /**
+       * In order to be backwards compatible with old tokens, 
+       * we need to call valueOf() on values which use the 
+       * RosettaColor class.
+       **/
+
+      var tempValue = transform(scale, val, val);
+      var value = tempValue !== undefined ? tempValue.valueOf() : tempValue;
 
       if (multiples[prop]) {
         var dirs = multiples[prop];

--- a/dist/esm/new-tests/css.test.js
+++ b/dist/esm/new-tests/css.test.js
@@ -1,4 +1,17 @@
+function _templateObject() {
+  var data = _taggedTemplateLiteralLoose(["\n  token         | value\n  ", "    | ", "\n  ", "      | ", "\n  ", "  | ", "\n  ", " | ", "\n"]);
+
+  _templateObject = function _templateObject() {
+    return data;
+  };
+
+  return data;
+}
+
+function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
+
 import css from '../css';
+import RosettaColor from '../testUtilities/RosettaColor';
 var theme = {
   breakpoints: {
     mobile: '@media mobile',
@@ -37,5 +50,24 @@ test('match breakpoints wildcard', function () {
     '@media tablet-100': {
       fontSize: 64
     }
+  });
+});
+test.each(_templateObject(), 'green', 'green', 'red', 'red', 'red.100', 'orange', 'blue.100', 'blue')('converts $token to $value', function (_ref) {
+  var token = _ref.token,
+      value = _ref.value;
+  var colorTheme = {
+    colors: {
+      green: 'green',
+      red: new RosettaColor(),
+      blue: {
+        '100': 'blue'
+      }
+    }
+  };
+  var resolved = css({
+    color: token
+  })(colorTheme);
+  expect(resolved).toEqual({
+    color: value
   });
 });

--- a/dist/esm/testUtilities/RosettaColor.js
+++ b/dist/esm/testUtilities/RosettaColor.js
@@ -1,0 +1,42 @@
+function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var RosettaColor =
+/*#__PURE__*/
+function (_String) {
+  _inheritsLoose(RosettaColor, _String);
+
+  function RosettaColor() {
+    var _this;
+
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _String.call(this, args) || this;
+    _this['100'] = 'orange';
+    _this['200'] = 'yellow';
+    return _this;
+  }
+
+  var _proto = RosettaColor.prototype;
+
+  _proto.valueOf = function valueOf() {
+    return 'red';
+  };
+
+  return RosettaColor;
+}(_wrapNativeSuper(String));
+
+export default RosettaColor;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tmp-styled-system",
   "main": "dist/cjs/styled-system.js",
   "module": "dist/esm/styled-system.js",
-  "version": "1.1.0",
+  "version": "6.2.0",
   "description": "",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tmp-styled-system",
   "main": "dist/cjs/styled-system.js",
   "module": "dist/esm/styled-system.js",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tmp-styled-system",
   "main": "dist/cjs/styled-system.js",
   "module": "dist/esm/styled-system.js",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm",

--- a/src/backwards-compat-tests/core/parser.test.js
+++ b/src/backwards-compat-tests/core/parser.test.js
@@ -1,17 +1,5 @@
 import { system } from '../../core';
-
-class RosettaColor extends String {
-  constructor(...args) {
-    super(args);
-
-    this['100'] = 'orange';
-    this['200'] = 'yellow';
-  }
-
-  valueOf() {
-    return 'red';
-  }
-}
+import RosettaColor from '../../testUtilities/RosettaColor';
 
 const theme = {
   colors: {

--- a/src/css.js
+++ b/src/css.js
@@ -277,7 +277,15 @@ export const css = args => (props = {}) => {
     const scaleName = get(scales, prop);
     const scale = get(theme, scaleName, get(theme, prop, {}));
     const transform = get(transforms, prop, get);
-    const value = transform(scale, val, val);
+    
+    /**
+     * In order to be backwards compatible with old tokens, 
+     * we need to call valueOf() on values which use the 
+     * RosettaColor class.
+     **/ 
+
+    const tempValue = transform(scale, val, val);
+    const value = tempValue !== undefined ? tempValue.valueOf() : tempValue;
 
     if (multiples[prop]) {
       const dirs = multiples[prop];

--- a/src/new-tests/css.test.js
+++ b/src/new-tests/css.test.js
@@ -1,4 +1,5 @@
 import css from '../css';
+import RosettaColor from '../testUtilities/RosettaColor';
 
 const theme = {
   breakpoints: {
@@ -42,5 +43,31 @@ test('match breakpoints wildcard', () => {
     '@media tablet-100': {
       fontSize: 64
     }
+  });
+});
+
+test.each`
+  token         | value
+  ${'green'}    | ${'green'}
+  ${'red'}      | ${'red'}
+  ${'red.100'}  | ${'orange'}
+  ${'blue.100'} | ${'blue'}
+`('converts $token to $value', ({ token, value }) => {
+  const colorTheme = {
+    colors: {
+      green: 'green',
+      red: new RosettaColor(),
+      blue: {
+        '100': 'blue'
+      }
+    }
+  };
+
+  const resolved = css({
+    color: token
+  })(colorTheme);
+
+  expect(resolved).toEqual({
+    color: value
   });
 });

--- a/src/testUtilities/RosettaColor.js
+++ b/src/testUtilities/RosettaColor.js
@@ -1,0 +1,14 @@
+class RosettaColor extends String {
+  constructor(...args) {
+    super(args);
+
+    this['100'] = 'orange';
+    this['200'] = 'yellow';
+  }
+
+  valueOf() {
+    return 'red';
+  }
+}
+
+export default RosettaColor;


### PR DESCRIPTION
This makes the `css` function work with our backwards compatible `RosettaColor` class. It checks if the color value is defined, and, if so, calls `valueOf` to get the primitive value. This allows us to resolve backwards compatible color tokens used in the `sx` prop.